### PR TITLE
Enable osx builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,76 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-10.13
+  timeoutInMinutes: 360
+  strategy:
+    maxParallel: 8
+    matrix:
+      osx_python2.7:
+        CONFIG: osx_python2.7
+        UPLOAD_PACKAGES: True
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      echo "Fast Finish"
+      
+
+  - script: |
+      echo "Removing homebrew from Azure to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+    displayName: Remove homebrew
+
+  - bash: |
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
+    displayName: Add conda to PATH
+
+  - script: |
+      source activate base
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+    displayName: 'Add conda-forge-ci-setup=2'
+
+  - script: |
+      source activate base
+      echo "Configuring conda."
+
+      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      export CI=azure
+      source run_conda_forge_build_setup
+      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+    env: {
+      OSX_FORCE_SDK_DOWNLOAD: "1"
+    }
+    displayName: Configure conda and conda-build
+
+  - script: |
+      source activate base
+      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Mangle compiler
+
+  - script: |
+      source activate base
+      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Generate build number clobber file
+
+  - script: |
+      source activate base
+      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    displayName: Build recipe
+
+  - script: |
+      source activate base
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    displayName: Upload package
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.12'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+fftw:
+- '3'
+glib:
+- '2.58'
+gsl:
+- '2.5'
+gst_plugins_base:
+- 1.14.4
+gstreamer:
+- 1.14.4
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.12'
+pin_run_as_build:
+  fftw:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstlal-calibration-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_python2.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9066&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gstlal-calibration-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
     </td>
   </tr>
   <tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 build:
   number: 0
   skip: true  # [win or py>=30]
-  skip: true  # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
See conda-forge/staged-recipes#10826 for the details of why this was necessary. This build number has not been bumped as this has zero impact on the existing linux packages.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
